### PR TITLE
fix sv_candidate_regions step: shape compatibilty error

### DIFF
--- a/src/grocsvs/stages/sv_candidate_regions.py
+++ b/src/grocsvs/stages/sv_candidate_regions.py
@@ -112,11 +112,17 @@ class SVCandidateRegionsStep(step.StepChunk):
         chromx_length = self.options.reference.chrom_lengths[self.chromx]
         chromy_length = self.options.reference.chrom_lengths[self.chromy]
 
-        hist = numpy.zeros((chromy_length/window_size+1,
-                            chromx_length/window_size+1))
+        num_chromy = chromy_length/window_size
+        num_chromx = chromx_length/window_size
 
-        p = numpy.zeros((chromy_length/window_size+1,
-                         chromx_length/window_size+1))
+        if chromy_length%window_size != 0:
+            num_chromy += 1
+
+        if chromx_length%window_size != 0:
+            num_chromx += 1
+
+        hist = numpy.zeros((num_chromy, num_chromx))
+        p =    numpy.zeros((num_chromy, num_chromx))
 
         hist[:] = numpy.nan
         p[:] = numpy.nan


### PR DESCRIPTION
When `chromy_length` or `chromx_length` is divisible by `window_size`, there is shape incompatibility error. The error is as following:
```
2020-03-13 10:02:23 - Traceback (most recent call last):
2020-03-13 10:02:23 -   File "/gnu/store/wgwybqc3vl3bhwcqb8pph2navk0h2pm2-grocsvs-0.2.6.1-1.ecd956a/lib/python2.7/site-packages/grocsvs/pipeline.py", line 87, in _run_chunk
2020-03-13 10:02:23 -     chunk.run()
2020-03-13 10:02:23 -   File "/gnu/store/wgwybqc3vl3bhwcqb8pph2navk0h2pm2-grocsvs-0.2.6.1-1.ecd956a/lib/python2.7/site-packages/grocsvs/stages/sv_candidate_regions.py", line 73, in run
2020-03-13 10:02:23 -     hist, p = self.get_barcode_overlaps()
2020-03-13 10:02:23 -   File "/gnu/store/wgwybqc3vl3bhwcqb8pph2navk0h2pm2-grocsvs-0.2.6.1-1.ecd956a/lib/python2.7/site-packages/grocsvs/stages/sv_candidate_regions.py", line 134, in get_barcode_overlaps
2020-03-13 10:02:23 -     chunk.chunkx*5000:(chunk.chunkx+1)*5000] = cur_hist
2020-03-13 10:02:23 - ValueError: could not broadcast input array from shape (2770,5000) into shape (2771,5000)
2020-03-13 10:02:23 - 
2020-03-13 10:02:23 - could not broadcast input array from shape (2770,5000) into shape (2771,5000)
```